### PR TITLE
Responsive markdown theme

### DIFF
--- a/_includes/themes/twitter/markdown.html
+++ b/_includes/themes/twitter/markdown.html
@@ -1,4 +1,4 @@
-<div class="page">
+<div class="page markdown">
   <div class="row-fluid">
     <div class="col-lg-8 col-lg-offset-1">
       <div class="page-header">

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -277,3 +277,14 @@ a:after {
   color: #31708f;
   background-color: #d9edf7;
 }
+
+.markdown {
+  display: inline-block;
+  max-width: 100%;
+}
+
+.markdown img {
+  display: block;
+  height: auto;
+  max-width: 100%;
+}


### PR DESCRIPTION
page markdown layout is not overlapped by top navbar, page max-width is set to 100%, img in markdown gets scaled down responsively
