### PR TITLE
Add the Creative Platform/AgroDesign lineup item

### DIFF
--- a/together/index.html
+++ b/together/index.html
@@ -184,6 +184,9 @@ og-description: All the Tech Communities of Thessaloniki in one place at the sam
               <td class="active table-team">Behance</td>
             </tr>
             <tr>
+              <td class="active table-team">Creative Platform/AgroDesign</td>
+            </tr>
+            <tr>
               <th class="table-stack table-stack-6" rowspan="2">Methodologies</td>
               <td class="active table-team">Agile</td>
             </tr>


### PR DESCRIPTION
As pinged by Panos Remoundos, the lineup items needed some updating to include the Creative Platform's one.
