### PR TITLE
Change link color for .calendar-link links

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -81,6 +81,11 @@ a:after {
     transition: color 0.1s ease-in, background 0.1s ease-in;
 }
 
+.calendar-link a {
+    color: #FFF;
+    font-size: larger;
+}
+
 /* Bootstrap Modifications */
  hr {
     display: block;


### PR DESCRIPTION
The color contrast was not so proper (green + red). Links should be better white color and larger.
