### PR TITLE
Color contrast error - Change color of links

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -55,7 +55,7 @@ h1, h2, h3, h4, h5, h6 {
 
 /* Links */
 a {
-    color: #f85c37;
+    color: blue;
     word-wrap: break-word;
 
     -webkit-transition: color 0.1s ease-in, background 0.1s ease-in;
@@ -222,7 +222,7 @@ a:after {
 }
 
 #contact .social a:hover {
-  background-color: #f85c37;
+  background-color: blue;
 }
 
 #contact .social {


### PR DESCRIPTION
Color contrast is too bad for links. A common user can see the contrast problem but in case we need some more info check here is a reference.
- http://snook.ca/technical/colour_contrast/colour.html#fg=F85C37,bg=74CFAE
Changing the link color to blue is a good option.