### PR TITLE
Add id to the slack form for easy linking

### DIFF
--- a/_includes/index/slack.html
+++ b/_includes/index/slack.html
@@ -1,4 +1,4 @@
-<div class="slack">
+<div id="slack-invte" class="slack">
   <form class="form-inline slack-form" target="_blank" novalidate>
     <div class="form-group form-group-lg">
       <div id="mc_embed_signup_scroll" class="field">


### PR DESCRIPTION
Add a HTML id to the Slack invite form container so the hashref can be used for linking directly to the form.