### PR TITLE
Add id to the slack form

### DIFF
--- a/_includes/index/slack.html
+++ b/_includes/index/slack.html
@@ -1,4 +1,4 @@
-<div class="slack">
+<div id="slack-invite" class="slack">
   <form class="form-inline slack-form" target="_blank" novalidate>
     <div class="form-group form-group-lg">
       <div id="mc_embed_signup_scroll" class="field">


### PR DESCRIPTION
This makes linking directly to the Slack invite form a bit more easy.