### PR TITLE
Minor mobile fixes, IE UI fixes 

### DIFF
--- a/_sass/_banner-ctas.scss
+++ b/_sass/_banner-ctas.scss
@@ -17,6 +17,8 @@
 
     img {
       height: 25px;
+      /* IE fix : Needs to have explicit width set*/
+      width:26px;
       display: inline-block;
       line-height: 1;
     }
@@ -42,7 +44,8 @@
   }
 
   .form-group input {
-    flex: 1;
+    /* IE fix: in some versions of IE (<=10), flex values must be complete and not abbreviations to work */
+    flex: 1 1 0;
     margin-left: 2.5vw;
     margin-right: 2.5vw;
     padding-left: 0;

--- a/_sass/_communities.scss
+++ b/_sass/_communities.scss
@@ -78,6 +78,8 @@
     font-weight: bold;
     text-align: center;
     padding:0 15px;
+    /* IE fix : Needs to have width set or it overflows*/
+    width:100%;
 
     a {
       color: #fff;

--- a/_sass/_communities.scss
+++ b/_sass/_communities.scss
@@ -77,6 +77,7 @@
     font-size: 22px;
     font-weight: bold;
     text-align: center;
+    padding:0 15px;
 
     a {
       color: #fff;

--- a/_sass/_footer.scss
+++ b/_sass/_footer.scss
@@ -6,6 +6,10 @@
 .social-links li {
   margin-left: 30px;
   margin-right: 30px;
+  @media (max-width: 768px){
+    margin-left:9px;
+    margin-right:9px;
+  }
 
   i.fa {
     font-size: 27px;

--- a/_sass/_hero.scss
+++ b/_sass/_hero.scss
@@ -50,5 +50,10 @@
       text-transform: uppercase;
       vertical-align: middle;
     }
+    
+    /* IE mobile fix: needs width set*/
+    img{
+      width:26px;
+    }
   }
 }


### PR DESCRIPTION
- Added  a media query for <768px , to wrap the social icons in the footer in a single line.

- Added a padding on the community titles, so that the titles will have at least the minimum amount of white-space needed ( Big titles were too close to the edges ).

-  Fixed SVG icons and inputs for IE >=10